### PR TITLE
Squeeze more code onto the screen

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -188,6 +188,16 @@ Tags: translation-ready
 	padding: 2rem 3rem;
 }
 
+/* Code Block */
+.wp-block-code {
+	font-size: 15px;
+}
+
+@media screen and (min-width: 1000px) {
+	.wp-block-code {
+		max-width: 1000px;
+	}
+}
 
 /* Form */
 div.wpcf7 {


### PR DESCRIPTION
Make the font size of all code blocks smaller, and on 1000px + viewports enlarge them to 1000px wide so fewer lines wrap.